### PR TITLE
Editor - Correct bitmap dimension in UV import

### DIFF
--- a/Scripts/Global/Editor Odm Data.lua
+++ b/Scripts/Global/Editor Odm Data.lua
@@ -79,7 +79,7 @@ local function WriteFacetData(f, t)
 			bw, bh = bw/2, bh/2
 		end
 		Editor.ImportBitmapU[facetId] = -(ux*vertX + uy*vertY + uz*vertZ) + t.ImportU*bw
-		Editor.ImportBitmapV[facetId] = -(vx*vertX + vy*vertY + vz*vertZ) + t.ImportV*bw
+		Editor.ImportBitmapV[facetId] = -(vx*vertX + vy*vertY + vz*vertZ) + t.ImportV*bh
 	end
 	Editor.UpdateBitmapU(t)
 	Editor.UpdateBitmapV(t)


### PR DESCRIPTION
Use texture height instead of width when calculating V. Solves a lot of texture alignment issues when importing models into outdoor maps.

Equivalent indoor code already works correctly:
https://github.com/GrayFace/MMExtension/blob/325d0643aa389db0f678fc82daf7063c443a0a28/Scripts/Global/Editor%20Data.lua#L483-L484