### PR TITLE
Editor Import - Don't change vt table values

### DIFF
--- a/Scripts/Global/Editor Import.lua
+++ b/Scripts/Global/Editor Import.lua
@@ -102,8 +102,7 @@ local function ParseObj(file, AddVertex, AddFacet, NewObject)
 			end
 			local a = t1[1] and vt[t1[1] % (#vt + 1)] or {}
 			if AddFacet then
-				a[2] = a[2] and 1 - a[2]  -- !!! tmp
-				AddFacet(t, texture, invis, unpack(a))
+				AddFacet(t, texture, invis, a[1], a[2] and 1 - a[2])
 			end
 		end
 	end


### PR DESCRIPTION
The current implementation modifies values in the `vt` tables when parsing a face, which causes issues if multiple faces in the .obj file share the same `vt` indexes.

This PR passes the calculated value directly to `AddFacet`, without modifying the table that may be used by other faces as well.

The line was marked with a "!!! tmp" comment, but it seems to be required to produce correct UVs during import. I assume this is related to `VFlipUnfixed`?